### PR TITLE
Disable BSP in the Jmh config

### DIFF
--- a/plugin/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala
+++ b/plugin/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala
@@ -62,7 +62,11 @@ object JmhPlugin extends AutoPlugin {
     sourceGenerators := Seq(Def.task { generateJmhSourcesAndResources.value._1 }.taskValue),
     resourceGenerators := Seq(Def.task { generateJmhSourcesAndResources.value._2 }.taskValue),
     generateJmhSourcesAndResources := generateBenchmarkSourcesAndResources(streams.value, crossTarget.value / "jmh-cache", (classDirectory in Jmh).value, sourceManaged.value, resourceManaged.value, generatorType.value, (dependencyClasspath in Jmh).value, new Run(scalaInstance.value, true, taskTemporaryDirectory.value)),
-    generateJmhSourcesAndResources := (generateJmhSourcesAndResources dependsOn(compile in Compile)).value
+    generateJmhSourcesAndResources := (generateJmhSourcesAndResources dependsOn(compile in Compile)).value,
+
+    // local copy of https://github.com/sbt/sbt/blob/e4231ac03903e174bc9975ee00d34064a1d1f373/main/src/main/scala/sbt/Keys.scala#L400
+    // so that it does not break on sbt version below 1.4.0
+    SettingKey[Boolean]("bspEnabled") := false
   )) ++ Seq(
     // settings in default
 


### PR DESCRIPTION
Importing a Jmh build target in IntelliJ or Metals triggers the Jmh source generation which triggers the compilation.
This is not user friendly because:
- it takes time to import the project
- it can compile in error and then it makes the entire import fail (we need more granularity in BSP to handle individual failures)

Importing the Jmh build target is often not useful because it shares its sources with the `Compile` or `Test` build target.

Related discussions:
- https://github.com/scalameta/metals/pull/2895
- https://github.com/sbt/sbt/issues/6546
- https://github.com/lampepfl/dotty/pull/11687
- https://github.com/scala/scala/pull/9673