### PR TITLE
Fix `sbt-jmh-tester`

### DIFF
--- a/sbt-jmh-tester/project/plugins.sbt
+++ b/sbt-jmh-tester/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % {
-  val is = io.Source.fromFile(new File("../version.sbt")).mkString
+  val is = scala.io.Source.fromFile(new File("../version.sbt")).mkString
   val it = is.replaceAll("version in ThisBuild := ", "").replaceAll("\"", "").replaceAll("\n", "")
   it
 }, "1.3", "2.12")


### PR DESCRIPTION
It fails on attempt to use like:
```
/Users/catap/src/sbt-jmh/sbt-jmh-tester/project/plugins.sbt:2: error: object Source is not a member of package sbt.io
  val is = io.Source.fromFile(new File("../version.sbt")).mkString
              ^

```